### PR TITLE
Add ImageGenerateCaptcha BIF and captcha component action

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,9 @@ repositories {
     mavenCentral()
 	maven {
 		url "https://www.javaxt.com/maven"
+		content {
+			includeGroup "javaxt"
+		}
 	}
 }
 

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `ImageGenerateCaptcha( height, width, text [, difficulty [, fonts [, fontSize]]] )` BIF for generating CAPTCHA images with configurable dimensions, font size, difficulty level (`low`/`medium`/`high`), and font list. Argument order is ColdFusion-compatible.
+- `<bx:image action="captcha">` component support with `text`, `width`, `height`, `fontSize`, `difficulty`, `fonts`, `destination`, `overwrite`, and `name` attributes. When neither `name` nor `destination` is specified, the image is automatically streamed to the browser.
+
 ## [1.5.0] - 2026-02-18
 
 - BLMODULES-139 Update writeToBrowser to accept format attribute

--- a/readme.md
+++ b/readme.md
@@ -240,6 +240,33 @@ img = imageReadBase64(base64String);
 img = imageNew("", 800, 600, "rgb", "white");
 ```
 
+### CAPTCHA Generation
+
+```javascript
+// Basic CAPTCHA (args: height, width, text)
+captcha = ImageGenerateCaptcha( 75, 200, "A3X9K2" );
+ImageWrite( captcha, "/path/to/captcha.png" );
+
+// With difficulty and fonts (ColdFusion-compatible arg order)
+captcha = ImageGenerateCaptcha( 35, 400, "loner" );
+captcha = ImageGenerateCaptcha( 35, 400, "loner", "high" );
+captcha = ImageGenerateCaptcha( 35, 400, "loner", "high", "serif,sansserif", 24 );
+
+// Via component — auto-streams to browser when no name/destination is given
+<bx:image action="captcha" text="A3X9K2" width="200" height="75" difficulty="medium" />
+
+// Store in variable for further processing
+<bx:image action="captcha" text="A3X9K2" width="200" height="75" name="captchaImg" />
+
+// Write directly to file
+<bx:image action="captcha" text="A3X9K2" destination="/path/to/captcha.png" />
+```
+
+**Difficulty levels:**
+- `low` — minimal character rotation, clean background
+- `medium` — moderate rotation, noise dots, crossing lines
+- `high` — heavy rotation, dense noise, wavy lines, random character colors
+
 ### Member Functions vs BIFs
 
 Most functions work both ways:
@@ -278,6 +305,7 @@ This module contributes the following BIFs:
 - [ImageDrawRoundRect](https://cfdocs.org/ImageDrawRoundRect)
 - [ImageDrawText](https://cfdocs.org/ImageDrawText)
 - [ImageFlip](https://cfdocs.org/ImageFlip)
+- [ImageGenerateCaptcha](https://cfdocs.org/ImageCreateCaptcha) - Generate a CAPTCHA image with distorted text. Args: `height, width, text [, difficulty [, fonts [, fontSize]]]`
 - [ImageGetBlob](https://cfdocs.org/ImageGetBlob)
 - [ImageGetBufferedImage](https://cfdocs.org/ImageGetBufferedImage)
 - [ImageGetExifMetaData](https://cfdocs.org/ImageGetExifMetaData)

--- a/src/main/java/ortus/boxlang/modules/image/BoxImage.java
+++ b/src/main/java/ortus/boxlang/modules/image/BoxImage.java
@@ -1679,17 +1679,17 @@ public class BoxImage implements IBoxBinaryRepresentable {
 			g.setFont( font );
 			g.setColor( captchaCharColor( difficulty, rng ) );
 
-			double maxAngle = switch ( difficulty.toLowerCase() ) {
-				case "medium" -> 15.0;
-				case "high" -> 25.0;
-				default -> 5.0;
-			};
-			double				angleDeg	= ( rng.nextDouble() * 2 - 1 ) * maxAngle;
-			int					jitter		= Math.max( 1, fontSize / 5 );
-			int					charX		= slotWidth * ( i + 1 ) + rng.nextInt( jitter ) * ( rng.nextBoolean() ? 1 : -1 );
-			int					charY		= baseY + rng.nextInt( jitter ) * ( rng.nextBoolean() ? 1 : -1 );
+			double			maxAngle	= switch ( difficulty.toLowerCase() ) {
+											case "medium" -> 15.0;
+											case "high" -> 25.0;
+											default -> 5.0;
+										};
+			double			angleDeg	= ( rng.nextDouble() * 2 - 1 ) * maxAngle;
+			int				jitter		= Math.max( 1, fontSize / 5 );
+			int				charX		= slotWidth * ( i + 1 ) + rng.nextInt( jitter ) * ( rng.nextBoolean() ? 1 : -1 );
+			int				charY		= baseY + rng.nextInt( jitter ) * ( rng.nextBoolean() ? 1 : -1 );
 
-			AffineTransform		saved		= g.getTransform();
+			AffineTransform	saved		= g.getTransform();
 			g.rotate( Math.toRadians( angleDeg ), charX, charY );
 			g.drawString( ch, charX, charY );
 			g.setTransform( saved );
@@ -1749,13 +1749,13 @@ public class BoxImage implements IBoxBinaryRepresentable {
 				GeneralPath	path	= new GeneralPath();
 				int			startY	= rng.nextInt( height );
 				path.moveTo( 0, startY );
-				int segments = 4;
-				int segWidth = width / segments;
+				int	segments	= 4;
+				int	segWidth	= width / segments;
 				for ( int s = 0; s < segments; s++ ) {
-					int ctrlX = segWidth * s + rng.nextInt( segWidth );
-					int ctrlY = rng.nextInt( height );
-					int endX = segWidth * ( s + 1 );
-					int endY = rng.nextInt( height );
+					int	ctrlX	= segWidth * s + rng.nextInt( segWidth );
+					int	ctrlY	= rng.nextInt( height );
+					int	endX	= segWidth * ( s + 1 );
+					int	endY	= rng.nextInt( height );
 					path.quadTo( ctrlX, ctrlY, endX, endY );
 				}
 				g.draw( path );

--- a/src/main/java/ortus/boxlang/modules/image/BoxImage.java
+++ b/src/main/java/ortus/boxlang/modules/image/BoxImage.java
@@ -51,6 +51,9 @@ import java.nio.file.Paths;
 import java.util.Base64;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Random;
+import java.awt.BasicStroke;
+import java.awt.geom.GeneralPath;
 
 import javax.imageio.ImageIO;
 
@@ -1634,6 +1637,133 @@ public class BoxImage implements IBoxBinaryRepresentable {
 		}
 
 		return result;
+	}
+
+	/**
+	 * Generates a CAPTCHA image with distorted text.
+	 * Matches the ColdFusion ImageCreateCaptcha() argument order: height, width, text, difficulty, fonts, fontSize.
+	 *
+	 * @param text       The text to render in the CAPTCHA
+	 * @param width      Image width in pixels
+	 * @param height     Image height in pixels
+	 * @param fontSize   Font size in points
+	 * @param difficulty Distortion level: "low", "medium", or "high"
+	 * @param fontNames  Array of font family names to randomly select per character (empty = use default)
+	 *
+	 * @return A new BoxImage containing the rendered CAPTCHA
+	 */
+	public static BoxImage generateCaptcha( String text, int width, int height, int fontSize, String difficulty, String[] fontNames ) {
+		Random			rng	= new Random();
+		BufferedImage	buf	= new BufferedImage( width, height, BufferedImage.TYPE_INT_RGB );
+		Graphics2D		g	= buf.createGraphics();
+
+		g.setRenderingHint( RenderingHints.KEY_ANTIALIASING, RenderingHints.VALUE_ANTIALIAS_ON );
+		g.setRenderingHint( RenderingHints.KEY_TEXT_ANTIALIASING, RenderingHints.VALUE_TEXT_ANTIALIAS_ON );
+
+		// Fill background
+		g.setColor( captchaBackgroundColor( difficulty, rng ) );
+		g.fillRect( 0, 0, width, height );
+
+		// Noise dots (medium/high only)
+		drawCaptchaNoiseDots( g, width, height, difficulty, rng );
+
+		// Render each character with random per-character rotation
+		int	charCount	= text.length();
+		int	slotWidth	= width / ( charCount + 1 );
+		int	baseY		= height / 2 + fontSize / 3;
+
+		for ( int i = 0; i < charCount; i++ ) {
+			String	ch		= String.valueOf( text.charAt( i ) );
+			String	family	= captchaPickFont( fontNames, rng );
+			Font	font	= new Font( family, Font.BOLD, fontSize );
+			g.setFont( font );
+			g.setColor( captchaCharColor( difficulty, rng ) );
+
+			double maxAngle = switch ( difficulty.toLowerCase() ) {
+				case "medium" -> 15.0;
+				case "high" -> 25.0;
+				default -> 5.0;
+			};
+			double				angleDeg	= ( rng.nextDouble() * 2 - 1 ) * maxAngle;
+			int					jitter		= Math.max( 1, fontSize / 5 );
+			int					charX		= slotWidth * ( i + 1 ) + rng.nextInt( jitter ) * ( rng.nextBoolean() ? 1 : -1 );
+			int					charY		= baseY + rng.nextInt( jitter ) * ( rng.nextBoolean() ? 1 : -1 );
+
+			AffineTransform		saved		= g.getTransform();
+			g.rotate( Math.toRadians( angleDeg ), charX, charY );
+			g.drawString( ch, charX, charY );
+			g.setTransform( saved );
+		}
+
+		// Crossing lines (medium/high only)
+		drawCaptchaCrossingLines( g, width, height, difficulty, rng );
+
+		g.dispose();
+		return new BoxImage( buf );
+	}
+
+	private static Color captchaBackgroundColor( String difficulty, Random rng ) {
+		return switch ( difficulty.toLowerCase() ) {
+			case "high" -> new Color( 200 + rng.nextInt( 56 ), 200 + rng.nextInt( 56 ), 200 + rng.nextInt( 56 ) );
+			case "medium" -> new Color( 230, 240, 255 );
+			default -> new Color( 250, 250, 250 );
+		};
+	}
+
+	private static Color captchaCharColor( String difficulty, Random rng ) {
+		if ( "high".equalsIgnoreCase( difficulty ) ) {
+			return new Color( rng.nextInt( 150 ), rng.nextInt( 150 ), rng.nextInt( 150 ) );
+		}
+		return Color.BLACK;
+	}
+
+	private static String captchaPickFont( String[] fontNames, Random rng ) {
+		if ( fontNames == null || fontNames.length == 0 ) {
+			return DEFAULT_FONT_FAMILY;
+		}
+		return fontNames[ rng.nextInt( fontNames.length ) ];
+	}
+
+	private static void drawCaptchaNoiseDots( Graphics2D g, int width, int height, String difficulty, Random rng ) {
+		int dotCount = switch ( difficulty.toLowerCase() ) {
+			case "high" -> 300;
+			case "medium" -> 80;
+			default -> 0;
+		};
+		for ( int d = 0; d < dotCount; d++ ) {
+			g.setColor( new Color( rng.nextInt( 200 ), rng.nextInt( 200 ), rng.nextInt( 200 ), 180 ) );
+			g.fillOval( rng.nextInt( width ), rng.nextInt( height ), 2, 2 );
+		}
+	}
+
+	private static void drawCaptchaCrossingLines( Graphics2D g, int width, int height, String difficulty, Random rng ) {
+		int lineCount = switch ( difficulty.toLowerCase() ) {
+			case "high" -> 3 + rng.nextInt( 3 );
+			case "medium" -> 2 + rng.nextInt( 2 );
+			default -> 0;
+		};
+		for ( int l = 0; l < lineCount; l++ ) {
+			g.setColor( new Color( rng.nextInt( 180 ), rng.nextInt( 180 ), rng.nextInt( 180 ), 200 ) );
+			g.setStroke( new BasicStroke( 1.5f ) );
+			if ( "high".equalsIgnoreCase( difficulty ) ) {
+				GeneralPath	path	= new GeneralPath();
+				int			startY	= rng.nextInt( height );
+				path.moveTo( 0, startY );
+				int segments = 4;
+				int segWidth = width / segments;
+				for ( int s = 0; s < segments; s++ ) {
+					int ctrlX = segWidth * s + rng.nextInt( segWidth );
+					int ctrlY = rng.nextInt( height );
+					int endX = segWidth * ( s + 1 );
+					int endY = rng.nextInt( height );
+					path.quadTo( ctrlX, ctrlY, endX, endY );
+				}
+				g.draw( path );
+			} else {
+				g.drawLine( rng.nextInt( width / 2 ), rng.nextInt( height ), width / 2 + rng.nextInt( width / 2 ), rng.nextInt( height ) );
+			}
+		}
+		g.setStroke( new BasicStroke( 1.0f ) );
 	}
 
 	/**

--- a/src/main/java/ortus/boxlang/modules/image/BoxImage.java
+++ b/src/main/java/ortus/boxlang/modules/image/BoxImage.java
@@ -1641,16 +1641,30 @@ public class BoxImage implements IBoxBinaryRepresentable {
 
 	/**
 	 * Generates a CAPTCHA image with distorted text.
-	 * Matches the ColdFusion ImageCreateCaptcha() argument order: height, width, text, difficulty, fonts, fontSize.
 	 *
-	 * @param text       The text to render in the CAPTCHA
-	 * @param width      Image width in pixels
-	 * @param height     Image height in pixels
-	 * @param fontSize   Font size in points
-	 * @param difficulty Distortion level: "low", "medium", or "high"
-	 * @param fontNames  Array of font family names to randomly select per character (empty = use default)
+	 * <p>
+	 * The image is created from scratch: a background is filled, optional noise dots are scattered,
+	 * each character is drawn individually with a random rotation and position jitter, and then
+	 * optional crossing lines are painted on top. The degree of all distortion is governed by the
+	 * {@code difficulty} parameter:
+	 * </p>
 	 *
-	 * @return A new BoxImage containing the rendered CAPTCHA
+	 * <ul>
+	 * <li><b>low</b> — near-white background, ±5° rotation per character, no noise or lines</li>
+	 * <li><b>medium</b> — light-blue background, ±15° rotation, 80 noise dots, 2–3 straight crossing lines</li>
+	 * <li><b>high</b> — random pastel background, ±25° rotation, 300 noise dots, 3–5 wavy bezier crossing
+	 * lines, random per-character colours</li>
+	 * </ul>
+	 *
+	 * @param text       The text string to render. Uppercase letters and digits are recommended.
+	 * @param width      Canvas width in pixels.
+	 * @param height     Canvas height in pixels.
+	 * @param fontSize   Font size in points.
+	 * @param difficulty Distortion level: {@code "low"}, {@code "medium"}, or {@code "high"}.
+	 * @param fontNames  Array of font family names to cycle through randomly per character.
+	 *                   Pass an empty array or {@code null} to use {@link #DEFAULT_FONT_FAMILY}.
+	 *
+	 * @return A new {@link BoxImage} containing the rendered CAPTCHA.
 	 */
 	public static BoxImage generateCaptcha( String text, int width, int height, int fontSize, String difficulty, String[] fontNames ) {
 		Random			rng	= new Random();
@@ -1702,6 +1716,15 @@ public class BoxImage implements IBoxBinaryRepresentable {
 		return new BoxImage( buf );
 	}
 
+	/**
+	 * Returns a background {@link Color} appropriate for the requested CAPTCHA difficulty.
+	 *
+	 * @param difficulty {@code "low"}, {@code "medium"}, or {@code "high"}
+	 * @param rng        Shared random-number generator
+	 *
+	 * @return A light background colour — near-white for low, a fixed light blue for medium,
+	 *         or a randomised pastel for high
+	 */
 	private static Color captchaBackgroundColor( String difficulty, Random rng ) {
 		return switch ( difficulty.toLowerCase() ) {
 			case "high" -> new Color( 200 + rng.nextInt( 56 ), 200 + rng.nextInt( 56 ), 200 + rng.nextInt( 56 ) );
@@ -1710,6 +1733,16 @@ public class BoxImage implements IBoxBinaryRepresentable {
 		};
 	}
 
+	/**
+	 * Returns the foreground {@link Color} to use for a single CAPTCHA character.
+	 * Low and medium difficulties always use black; high difficulty returns a random dark colour
+	 * so adjacent characters are visually distinct.
+	 *
+	 * @param difficulty {@code "low"}, {@code "medium"}, or {@code "high"}
+	 * @param rng        Shared random-number generator
+	 *
+	 * @return A {@link Color} for the character glyph
+	 */
 	private static Color captchaCharColor( String difficulty, Random rng ) {
 		if ( "high".equalsIgnoreCase( difficulty ) ) {
 			return new Color( rng.nextInt( 150 ), rng.nextInt( 150 ), rng.nextInt( 150 ) );
@@ -1717,6 +1750,16 @@ public class BoxImage implements IBoxBinaryRepresentable {
 		return Color.BLACK;
 	}
 
+	/**
+	 * Picks a font family name at random from the supplied array.
+	 * Falls back to {@link #DEFAULT_FONT_FAMILY} when the array is {@code null} or empty,
+	 * which guarantees a valid logical font is always available regardless of the JVM environment.
+	 *
+	 * @param fontNames Array of font family names provided by the caller
+	 * @param rng       Shared random-number generator
+	 *
+	 * @return A font family name string suitable for passing to {@link Font#Font(String, int, int)}
+	 */
 	private static String captchaPickFont( String[] fontNames, Random rng ) {
 		if ( fontNames == null || fontNames.length == 0 ) {
 			return DEFAULT_FONT_FAMILY;
@@ -1724,6 +1767,17 @@ public class BoxImage implements IBoxBinaryRepresentable {
 		return fontNames[ rng.nextInt( fontNames.length ) ];
 	}
 
+	/**
+	 * Scatters small noise dots over the CAPTCHA canvas.
+	 * The number of dots scales with difficulty: 0 for low, 80 for medium, 300 for high.
+	 * Each dot is a 2×2 semi-transparent oval drawn at a random position and colour.
+	 *
+	 * @param g          Active {@link Graphics2D} context
+	 * @param width      Canvas width in pixels
+	 * @param height     Canvas height in pixels
+	 * @param difficulty {@code "low"}, {@code "medium"}, or {@code "high"}
+	 * @param rng        Shared random-number generator
+	 */
 	private static void drawCaptchaNoiseDots( Graphics2D g, int width, int height, String difficulty, Random rng ) {
 		int dotCount = switch ( difficulty.toLowerCase() ) {
 			case "high" -> 300;
@@ -1736,6 +1790,23 @@ public class BoxImage implements IBoxBinaryRepresentable {
 		}
 	}
 
+	/**
+	 * Draws random lines across the CAPTCHA canvas to interfere with automated character segmentation.
+	 *
+	 * <ul>
+	 * <li><b>low</b> — no lines drawn</li>
+	 * <li><b>medium</b> — 2–3 straight diagonal lines</li>
+	 * <li><b>high</b> — 3–5 quadratic bezier (wavy) lines spanning the full canvas width</li>
+	 * </ul>
+	 *
+	 * The stroke width is 1.5 px for all lines; the stroke is reset to 1.0 px after drawing.
+	 *
+	 * @param g          Active {@link Graphics2D} context
+	 * @param width      Canvas width in pixels
+	 * @param height     Canvas height in pixels
+	 * @param difficulty {@code "low"}, {@code "medium"}, or {@code "high"}
+	 * @param rng        Shared random-number generator
+	 */
 	private static void drawCaptchaCrossingLines( Graphics2D g, int width, int height, String difficulty, Random rng ) {
 		int lineCount = switch ( difficulty.toLowerCase() ) {
 			case "high" -> 3 + rng.nextInt( 3 );

--- a/src/main/java/ortus/boxlang/modules/image/bifs/ImageGenerateCaptcha.java
+++ b/src/main/java/ortus/boxlang/modules/image/bifs/ImageGenerateCaptcha.java
@@ -75,11 +75,11 @@ public class ImageGenerateCaptcha extends BIF {
 			difficulty = "low";
 		}
 
-		String[] fontList = ( fontsArg == null || fontsArg.isEmpty() )
+		String[]	fontList	= ( fontsArg == null || fontsArg.isEmpty() )
 		    ? new String[ 0 ]
 		    : fontsArg.split( "\\s*,\\s*" );
 
-		BoxImage captcha = BoxImage.generateCaptcha( text, width, height, fontSize, difficulty, fontList );
+		BoxImage	captcha		= BoxImage.generateCaptcha( text, width, height, fontSize, difficulty, fontList );
 
 		if ( destination != null && !destination.isEmpty() ) {
 			String resolvedPath = FileSystemUtil.expandPath( context, destination ).absolutePath().toString();

--- a/src/main/java/ortus/boxlang/modules/image/bifs/ImageGenerateCaptcha.java
+++ b/src/main/java/ortus/boxlang/modules/image/bifs/ImageGenerateCaptcha.java
@@ -1,0 +1,95 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2024] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ortus.boxlang.modules.image.bifs;
+
+import java.util.Set;
+
+import ortus.boxlang.modules.image.BoxImage;
+import ortus.boxlang.modules.image.util.KeyDictionary;
+import ortus.boxlang.runtime.bifs.BIF;
+import ortus.boxlang.runtime.bifs.BoxBIF;
+import ortus.boxlang.runtime.context.IBoxContext;
+import ortus.boxlang.runtime.dynamic.casters.IntegerCaster;
+import ortus.boxlang.runtime.dynamic.casters.StringCaster;
+import ortus.boxlang.runtime.scopes.ArgumentsScope;
+import ortus.boxlang.runtime.types.Argument;
+import ortus.boxlang.runtime.types.exceptions.BoxRuntimeException;
+import ortus.boxlang.runtime.util.FileSystemUtil;
+import ortus.boxlang.runtime.validation.Validator;
+
+/**
+ * Generates a CAPTCHA image with distorted text.
+ * Argument order matches ColdFusion's ImageCreateCaptcha(): height, width, text [, difficulty [, fonts [, fontSize]]]
+ */
+@BoxBIF
+public class ImageGenerateCaptcha extends BIF {
+
+	public ImageGenerateCaptcha() {
+		super();
+		declaredArguments = new Argument[] {
+		    new Argument( false, "numeric", KeyDictionary.height, 75 ),
+		    new Argument( false, "numeric", KeyDictionary.width, 200 ),
+		    new Argument( true, "string", KeyDictionary.text, Set.of( Validator.REQUIRED, Validator.NON_EMPTY ) ),
+		    new Argument( false, "string", KeyDictionary.difficulty, "low" ),
+		    new Argument( false, "string", KeyDictionary.fonts, "" ),
+		    new Argument( false, "numeric", KeyDictionary.fontSize, 24 ),
+		    new Argument( false, "string", KeyDictionary.destination, "" ),
+		    new Argument( false, "boolean", KeyDictionary.overwrite, false ),
+		};
+	}
+
+	/**
+	 * Generates and returns a CAPTCHA image.
+	 *
+	 * @param context   The context in which the BIF is being invoked.
+	 * @param arguments Argument scope for the BIF.
+	 *
+	 * @return The generated CAPTCHA as a BoxImage
+	 */
+	public BoxImage _invoke( IBoxContext context, ArgumentsScope arguments ) {
+		int		height		= IntegerCaster.cast( arguments.get( KeyDictionary.height ) );
+		int		width		= IntegerCaster.cast( arguments.get( KeyDictionary.width ) );
+		String	text		= arguments.getAsString( KeyDictionary.text );
+		String	difficulty	= arguments.getAsString( KeyDictionary.difficulty );
+		String	fontsArg	= StringCaster.cast( arguments.get( KeyDictionary.fonts ) );
+		int		fontSize	= IntegerCaster.cast( arguments.get( KeyDictionary.fontSize ) );
+		String	destination	= StringCaster.cast( arguments.get( KeyDictionary.destination ) );
+		boolean	overwrite	= ( boolean ) arguments.get( KeyDictionary.overwrite );
+
+		if ( difficulty == null || difficulty.isEmpty() ) {
+			difficulty = "low";
+		}
+
+		String[] fontList = ( fontsArg == null || fontsArg.isEmpty() )
+		    ? new String[ 0 ]
+		    : fontsArg.split( "\\s*,\\s*" );
+
+		BoxImage captcha = BoxImage.generateCaptcha( text, width, height, fontSize, difficulty, fontList );
+
+		if ( destination != null && !destination.isEmpty() ) {
+			String resolvedPath = FileSystemUtil.expandPath( context, destination ).absolutePath().toString();
+			if ( !overwrite && FileSystemUtil.exists( resolvedPath ) ) {
+				throw new BoxRuntimeException( "Unable to write captcha image, destination exists: " + resolvedPath );
+			}
+			captcha.write( resolvedPath );
+		}
+
+		return captcha;
+	}
+
+}

--- a/src/main/java/ortus/boxlang/modules/image/bifs/ImageGenerateCaptcha.java
+++ b/src/main/java/ortus/boxlang/modules/image/bifs/ImageGenerateCaptcha.java
@@ -33,8 +33,26 @@ import ortus.boxlang.runtime.util.FileSystemUtil;
 import ortus.boxlang.runtime.validation.Validator;
 
 /**
- * Generates a CAPTCHA image with distorted text.
- * Argument order matches ColdFusion's ImageCreateCaptcha(): height, width, text [, difficulty [, fonts [, fontSize]]]
+ * Generates a CAPTCHA image with distorted text designed to be human-readable but
+ * resistant to automated parsing.
+ *
+ * <p>
+ * Argument order is compatible with ColdFusion's {@code ImageCreateCaptcha()}:
+ * {@code height, width, text [, difficulty [, fonts [, fontSize]]]}
+ * </p>
+ *
+ * <h3>Examples</h3>
+ *
+ * <pre>
+ * // Basic usage
+ * captcha = ImageGenerateCaptcha( 75, 200, "A3X9K2" );
+ * ImageWrite( captcha, "/path/to/captcha.png" );
+ *
+ * // With difficulty and font options (ColdFusion-compatible positional form)
+ * captcha = ImageGenerateCaptcha( 35, 400, "loner" );
+ * captcha = ImageGenerateCaptcha( 35, 400, "loner", "high" );
+ * captcha = ImageGenerateCaptcha( 35, 400, "loner", "high", "serif,sansserif", 24 );
+ * </pre>
  */
 @BoxBIF
 public class ImageGenerateCaptcha extends BIF {
@@ -54,12 +72,36 @@ public class ImageGenerateCaptcha extends BIF {
 	}
 
 	/**
-	 * Generates and returns a CAPTCHA image.
+	 * Generates and returns a CAPTCHA image with distorted text.
 	 *
 	 * @param context   The context in which the BIF is being invoked.
 	 * @param arguments Argument scope for the BIF.
 	 *
-	 * @return The generated CAPTCHA as a BoxImage
+	 * @argument.height Height of the generated image in pixels. Defaults to 75.
+	 *
+	 * @argument.width Width of the generated image in pixels. Defaults to 200.
+	 *
+	 * @argument.text The text string to render in the CAPTCHA image. Required. Uppercase letters
+	 *                and digits are recommended for readability.
+	 *
+	 * @argument.difficulty Controls the level of visual distortion applied to the image.
+	 *                      One of {@code low} (minimal rotation, clean background),
+	 *                      {@code medium} (moderate rotation, noise dots, crossing lines), or
+	 *                      {@code high} (heavy rotation, dense noise, wavy lines, random character colors).
+	 *                      Defaults to {@code low}.
+	 *
+	 * @argument.fonts Comma-separated list of font family names to randomly select per character,
+	 *                 e.g. {@code "Arial,Verdana,Georgia"}. Defaults to the JVM's default sans-serif font.
+	 *
+	 * @argument.fontSize Font size in points. Defaults to 24.
+	 *
+	 * @argument.destination Optional file path to write the generated PNG to. If omitted the image
+	 *                       is only returned, not written to disk.
+	 *
+	 * @argument.overwrite When {@code true}, overwrites an existing file at {@code destination}.
+	 *                     Defaults to {@code false}.
+	 *
+	 * @return The generated CAPTCHA as a BoxImage.
 	 */
 	public BoxImage _invoke( IBoxContext context, ArgumentsScope arguments ) {
 		int		height		= IntegerCaster.cast( arguments.get( KeyDictionary.height ) );

--- a/src/main/java/ortus/boxlang/modules/image/components/Image.java
+++ b/src/main/java/ortus/boxlang/modules/image/components/Image.java
@@ -121,26 +121,26 @@ public class Image extends Component {
 				if ( captchaText == null || captchaText.isEmpty() ) {
 					throw new BoxRuntimeException( "The text attribute is required for the captcha action" );
 				}
-				int captchaWidth = attributes.get( KeyDictionary.width ) != null
+				int		captchaWidth		= attributes.get( KeyDictionary.width ) != null
 				    ? IntegerCaster.cast( attributes.get( KeyDictionary.width ) )
 				    : 200;
-				int captchaHeight = attributes.get( KeyDictionary.height ) != null
+				int		captchaHeight		= attributes.get( KeyDictionary.height ) != null
 				    ? IntegerCaster.cast( attributes.get( KeyDictionary.height ) )
 				    : 75;
-				int captchaFontSize = attributes.get( KeyDictionary.fontSize ) != null
+				int		captchaFontSize		= attributes.get( KeyDictionary.fontSize ) != null
 				    ? IntegerCaster.cast( attributes.get( KeyDictionary.fontSize ) )
 				    : 24;
-				String captchaDifficulty = attributes.getAsString( KeyDictionary.difficulty );
+				String	captchaDifficulty	= attributes.getAsString( KeyDictionary.difficulty );
 				if ( captchaDifficulty == null || captchaDifficulty.isEmpty() )
 					captchaDifficulty = "low";
-				String fontsAttr = attributes.getAsString( KeyDictionary.fonts );
-				String[] captchaFonts = ( fontsAttr == null || fontsAttr.isEmpty() )
+				String		fontsAttr		= attributes.getAsString( KeyDictionary.fonts );
+				String[]	captchaFonts	= ( fontsAttr == null || fontsAttr.isEmpty() )
 				    ? new String[ 0 ]
 				    : fontsAttr.split( "\\s*,\\s*" );
 
 				image = BoxImage.generateCaptcha( captchaText, captchaWidth, captchaHeight, captchaFontSize, captchaDifficulty, captchaFonts );
 
-				String captchaDest = StringCaster.cast( attributes.get( KeyDictionary.destination ) );
+				String captchaDest = attributes.getAsString( KeyDictionary.destination );
 				if ( captchaDest != null && !captchaDest.isEmpty() ) {
 					boolean captchaOverwrite = BooleanCaster.cast( attributes.get( KeyDictionary.overwrite ) );
 					if ( !captchaOverwrite && FileSystemUtil.exists( captchaDest ) ) {
@@ -152,8 +152,8 @@ public class Image extends Component {
 				putImageInContext( image, context, attributes );
 
 				// When no destination or name is given, stream directly to browser (matches cfimage behavior)
-				String captchaName = attributes.getAsString( KeyDictionary.name );
-				boolean hasCaptchaOutput = ( captchaDest != null && !captchaDest.isEmpty() )
+				String	captchaName			= attributes.getAsString( KeyDictionary.name );
+				boolean	hasCaptchaOutput	= ( captchaDest != null && !captchaDest.isEmpty() )
 				    || ( captchaName != null && !captchaName.isEmpty() );
 				if ( !hasCaptchaOutput ) {
 					imageService.writeToBrowser( context, image, attributes );

--- a/src/main/java/ortus/boxlang/modules/image/components/Image.java
+++ b/src/main/java/ortus/boxlang/modules/image/components/Image.java
@@ -87,18 +87,71 @@ public class Image extends Component {
 	}
 
 	/**
-	 * An example component that says hello
+	 * Performs image operations based on the {@code action} attribute.
+	 *
+	 * <p>
+	 * Supported actions: {@code border}, {@code captcha}, {@code convert}, {@code info},
+	 * {@code read}, {@code resize}, {@code rotate}, {@code write}, {@code writeToBrowser}.
+	 * </p>
 	 *
 	 * @param context        The context in which the Component is being invoked
 	 * @param attributes     The attributes to the Component
 	 * @param body           The body of the Component
 	 * @param executionState The execution state of the Component
 	 *
-	 * @attribute.name The name of the person greeting us.
+	 * @attribute.action The image operation to perform. Required. One of:
+	 *                   {@code border}, {@code captcha}, {@code convert}, {@code info},
+	 *                   {@code read}, {@code resize}, {@code rotate}, {@code write}, {@code writeToBrowser}.
 	 *
-	 * @attribute.location The location of the person.
+	 * @attribute.source The image variable, file path, or URL to operate on.
+	 *                   Required for all actions except {@code captcha}.
 	 *
-	 * @attribute.shout Whether the person is shouting or not.
+	 * @attribute.name Variable name in which to store the resulting image.
+	 *                 Used by {@code read}, {@code resize}, {@code border}, {@code captcha}.
+	 *
+	 * @attribute.destination File path to write the image to.
+	 *                        Used by {@code write}, {@code convert}, {@code rotate}, {@code captcha}.
+	 *
+	 * @attribute.overwrite When {@code true}, overwrites an existing file at {@code destination}.
+	 *                      Defaults to {@code false}.
+	 *
+	 * @attribute.width Target width in pixels. Used by {@code resize} and {@code captcha}.
+	 *
+	 * @attribute.height Target height in pixels. Used by {@code resize} and {@code captcha}.
+	 *
+	 * @attribute.angle Rotation angle in degrees. Used by {@code rotate}.
+	 *
+	 * @attribute.color Border color as a named color or hex value. Used by {@code border}.
+	 *
+	 * @attribute.thickness Border thickness in pixels. Used by {@code border}.
+	 *
+	 * @attribute.text The text string to render in the CAPTCHA image.
+	 *                 Required for {@code captcha} action.
+	 *
+	 * @attribute.difficulty CAPTCHA distortion level: {@code low}, {@code medium}, or {@code high}.
+	 *                       Defaults to {@code low}. Used by {@code captcha}.
+	 *
+	 * @attribute.fonts Comma-separated font family names for CAPTCHA text rendering,
+	 *                  e.g. {@code "Arial,Verdana,Georgia"}. Used by {@code captcha}.
+	 *
+	 * @attribute.fontSize Font size in points for CAPTCHA text. Defaults to 24.
+	 *                     Used by {@code captcha}.
+	 *
+	 * @attribute.structName Variable name in which to store the image info struct.
+	 *                       Used by {@code info}.
+	 *
+	 * @attribute.format Image format for conversion, e.g. {@code png}, {@code jpg}.
+	 *                   Used by {@code convert} and {@code writeToBrowser}.
+	 *
+	 * @attribute.quality Output quality (0–1) for lossy formats such as JPEG.
+	 *                    Used by {@code write} and {@code writeToBrowser}.
+	 *
+	 * @attribute.isBase64 When {@code true}, treats the {@code source} value as a Base64-encoded
+	 *                     image string. Used by {@code read}.
+	 *
+	 * @attribute.interpolation Interpolation algorithm for resizing.
+	 *                          One of {@code bilinear}, {@code bicubic}, {@code nearestNeighbor}.
+	 *                          Defaults to {@code bilinear}. Used by {@code resize}.
 	 *
 	 */
 	public BodyResult _invoke( IBoxContext context, IStruct attributes, ComponentBody body, IStruct executionState ) {

--- a/src/main/java/ortus/boxlang/modules/image/components/Image.java
+++ b/src/main/java/ortus/boxlang/modules/image/components/Image.java
@@ -116,9 +116,50 @@ public class Image extends Component {
 				putImageInContext( image, context, attributes );
 
 				break;
-			case "captcha" :
-				// Handle captcha action
+			case "captcha" : {
+				String captchaText = attributes.getAsString( KeyDictionary.text );
+				if ( captchaText == null || captchaText.isEmpty() ) {
+					throw new BoxRuntimeException( "The text attribute is required for the captcha action" );
+				}
+				int captchaWidth = attributes.get( KeyDictionary.width ) != null
+				    ? IntegerCaster.cast( attributes.get( KeyDictionary.width ) )
+				    : 200;
+				int captchaHeight = attributes.get( KeyDictionary.height ) != null
+				    ? IntegerCaster.cast( attributes.get( KeyDictionary.height ) )
+				    : 75;
+				int captchaFontSize = attributes.get( KeyDictionary.fontSize ) != null
+				    ? IntegerCaster.cast( attributes.get( KeyDictionary.fontSize ) )
+				    : 24;
+				String captchaDifficulty = attributes.getAsString( KeyDictionary.difficulty );
+				if ( captchaDifficulty == null || captchaDifficulty.isEmpty() )
+					captchaDifficulty = "low";
+				String fontsAttr = attributes.getAsString( KeyDictionary.fonts );
+				String[] captchaFonts = ( fontsAttr == null || fontsAttr.isEmpty() )
+				    ? new String[ 0 ]
+				    : fontsAttr.split( "\\s*,\\s*" );
+
+				image = BoxImage.generateCaptcha( captchaText, captchaWidth, captchaHeight, captchaFontSize, captchaDifficulty, captchaFonts );
+
+				String captchaDest = StringCaster.cast( attributes.get( KeyDictionary.destination ) );
+				if ( captchaDest != null && !captchaDest.isEmpty() ) {
+					boolean captchaOverwrite = BooleanCaster.cast( attributes.get( KeyDictionary.overwrite ) );
+					if ( !captchaOverwrite && FileSystemUtil.exists( captchaDest ) ) {
+						throw new BoxRuntimeException( "Unable to write captcha image, destination exists: " + captchaDest );
+					}
+					image.write( captchaDest );
+				}
+
+				putImageInContext( image, context, attributes );
+
+				// When no destination or name is given, stream directly to browser (matches cfimage behavior)
+				String captchaName = attributes.getAsString( KeyDictionary.name );
+				boolean hasCaptchaOutput = ( captchaDest != null && !captchaDest.isEmpty() )
+				    || ( captchaName != null && !captchaName.isEmpty() );
+				if ( !hasCaptchaOutput ) {
+					imageService.writeToBrowser( context, image, attributes );
+				}
 				break;
+			}
 			case "convert" :
 				// Handle convert action
 				image = getImageFromContext( context, attributes );

--- a/src/test/java/ortus/boxlang/modules/image/bifs/ImageGenerateCaptchaTest.java
+++ b/src/test/java/ortus/boxlang/modules/image/bifs/ImageGenerateCaptchaTest.java
@@ -1,0 +1,210 @@
+/**
+ * [BoxLang]
+ *
+ * Copyright [2024] [Ortus Solutions, Corp]
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ortus.boxlang.modules.image.bifs;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import ortus.boxlang.compiler.parser.BoxSourceType;
+import ortus.boxlang.modules.image.BaseIntegrationTest;
+import ortus.boxlang.modules.image.BoxImage;
+import ortus.boxlang.runtime.scopes.Key;
+
+/**
+ * Tests for ImageGenerateCaptcha BIF.
+ * Argument order matches ColdFusion: height, width, text [, difficulty [, fonts [, fontSize]]]
+ */
+public class ImageGenerateCaptchaTest extends BaseIntegrationTest {
+
+	private static final String GENERATED_DIR = "src/test/resources/generated/";
+
+	@BeforeAll
+	public static void ensureGeneratedDir() {
+		new File( GENERATED_DIR ).mkdirs();
+	}
+
+	@DisplayName( "It generates a captcha and returns a BoxImage" )
+	@Test
+	public void testGenerateCaptchaReturnType() {
+		runtime.executeSource( """
+		    result = ImageGenerateCaptcha( 75, 200, "ABCD" );
+		""", context );
+
+		assertThat( variables.get( result ) ).isInstanceOf( BoxImage.class );
+	}
+
+	@DisplayName( "It generates a captcha with the specified dimensions" )
+	@Test
+	public void testGenerateCaptchaDimensions() {
+		runtime.executeSource( """
+		    result = ImageGenerateCaptcha( 100, 300, "HELLO" );
+		    w = result.getWidth();
+		    h = result.getHeight();
+		""", context );
+
+		assertThat( ( int ) variables.get( Key.of( "w" ) ) ).isEqualTo( 300 );
+		assertThat( ( int ) variables.get( Key.of( "h" ) ) ).isEqualTo( 100 );
+	}
+
+	@DisplayName( "It generates a captcha with difficulty=low and writes to file" )
+	@Test
+	public void testGenerateCaptchaLow() throws IOException {
+		String filePath = GENERATED_DIR + "captcha-low.png";
+		runtime.executeSource( """
+		    result = ImageGenerateCaptcha( 75, 200, "WXYZ", "low" );
+		    ImageWrite( result, "%s" );
+		""".formatted( filePath ), context );
+
+		Path p = Paths.get( filePath );
+		assertThat( Files.exists( p ) ).isTrue();
+		assertThat( Files.size( p ) ).isGreaterThan( 0L );
+	}
+
+	@DisplayName( "It generates a captcha with difficulty=medium" )
+	@Test
+	public void testGenerateCaptchaMedium() throws IOException {
+		String filePath = GENERATED_DIR + "captcha-medium.png";
+		runtime.executeSource( """
+		    result = ImageGenerateCaptcha( 75, 200, "WXYZ", "medium" );
+		    ImageWrite( result, "%s" );
+		""".formatted( filePath ), context );
+
+		Path p = Paths.get( filePath );
+		assertThat( Files.exists( p ) ).isTrue();
+		assertThat( Files.size( p ) ).isGreaterThan( 0L );
+	}
+
+	@DisplayName( "It generates a captcha with difficulty=high" )
+	@Test
+	public void testGenerateCaptchaHigh() throws IOException {
+		String filePath = GENERATED_DIR + "captcha-high.png";
+		runtime.executeSource( """
+		    result = ImageGenerateCaptcha( 75, 200, "WXYZ", "high" );
+		    ImageWrite( result, "%s" );
+		""".formatted( filePath ), context );
+
+		Path p = Paths.get( filePath );
+		assertThat( Files.exists( p ) ).isTrue();
+		assertThat( Files.size( p ) ).isGreaterThan( 0L );
+	}
+
+	@DisplayName( "It generates a captcha with custom fonts" )
+	@Test
+	public void testGenerateCaptchaWithFonts() throws IOException {
+		String filePath = GENERATED_DIR + "captcha-fonts.png";
+		runtime.executeSource( """
+		    result = ImageGenerateCaptcha( 75, 200, "CODE", "low", "SansSerif,Serif" );
+		    ImageWrite( result, "%s" );
+		""".formatted( filePath ), context );
+
+		Path p = Paths.get( filePath );
+		assertThat( Files.exists( p ) ).isTrue();
+		assertThat( Files.size( p ) ).isGreaterThan( 0L );
+	}
+
+	@DisplayName( "It generates a captcha with custom fontSize" )
+	@Test
+	public void testGenerateCaptchaWithFontSize() throws IOException {
+		String filePath = GENERATED_DIR + "captcha-fontsize.png";
+		runtime.executeSource( """
+		    result = ImageGenerateCaptcha( 100, 400, "BIG", "low", "", 36 );
+		    ImageWrite( result, "%s" );
+		""".formatted( filePath ), context );
+
+		Path p = Paths.get( filePath );
+		assertThat( Files.exists( p ) ).isTrue();
+		assertThat( Files.size( p ) ).isGreaterThan( 0L );
+		BoxImage img = ( BoxImage ) variables.get( result );
+		assertThat( img.getWidth() ).isEqualTo( 400 );
+		assertThat( img.getHeight() ).isEqualTo( 100 );
+	}
+
+	@DisplayName( "It matches the ColdFusion 3-arg form: ImageGenerateCaptcha(height, width, text)" )
+	@Test
+	public void testColdFusionCompatThreeArgs() {
+		runtime.executeSource( """
+		    result = ImageGenerateCaptcha( 35, 400, "loner" );
+		    w = result.getWidth();
+		    h = result.getHeight();
+		""", context );
+
+		assertThat( ( int ) variables.get( Key.of( "w" ) ) ).isEqualTo( 400 );
+		assertThat( ( int ) variables.get( Key.of( "h" ) ) ).isEqualTo( 35 );
+	}
+
+	@DisplayName( "It matches the ColdFusion 4-arg form: ImageGenerateCaptcha(height, width, text, difficulty)" )
+	@Test
+	public void testColdFusionCompatFourArgs() {
+		runtime.executeSource( """
+		    result = ImageGenerateCaptcha( 35, 400, "loner", "high" );
+		""", context );
+
+		assertThat( variables.get( result ) ).isInstanceOf( BoxImage.class );
+	}
+
+	@DisplayName( "It matches the ColdFusion 6-arg form: ImageGenerateCaptcha(height, width, text, difficulty, fonts, fontSize)" )
+	@Test
+	public void testColdFusionCompatSixArgs() {
+		runtime.executeSource( """
+		    result = ImageGenerateCaptcha( 35, 400, "loner", "high", "serif,sansserif", 24 );
+		""", context );
+
+		assertThat( variables.get( result ) ).isInstanceOf( BoxImage.class );
+	}
+
+	@DisplayName( "It generates a captcha via bx:image component with name" )
+	@Test
+	public void testCaptchaComponentWithName() {
+		runtime.executeSource( """
+		    <bx:image action="captcha" text="COMP" width="250" height="80" name="myCaptcha" />
+		""", context, BoxSourceType.BOXTEMPLATE );
+
+		BoxImage img = ( BoxImage ) variables.get( Key.of( "myCaptcha" ) );
+		assertThat( img ).isNotNull();
+		assertThat( img.getWidth() ).isEqualTo( 250 );
+		assertThat( img.getHeight() ).isEqualTo( 80 );
+	}
+
+	@DisplayName( "It generates a captcha via bx:image component with destination" )
+	@Test
+	public void testCaptchaComponentWithDestination() throws IOException {
+		String filePath = GENERATED_DIR + "captcha-component.png";
+		Files.deleteIfExists( Paths.get( filePath ) );
+
+		runtime.executeSource( """
+		    <bx:image action="captcha" text="COMP" width="200" height="75"
+		              difficulty="medium" destination="%s" overwrite=true name="myCaptcha" />
+		""".formatted( filePath ), context, BoxSourceType.BOXTEMPLATE );
+
+		assertThat( Files.exists( Paths.get( filePath ) ) ).isTrue();
+		assertThat( Files.size( Paths.get( filePath ) ) ).isGreaterThan( 0L );
+
+		BoxImage img = ( BoxImage ) variables.get( Key.of( "myCaptcha" ) );
+		assertThat( img ).isNotNull();
+	}
+
+}

--- a/src/test/java/ortus/boxlang/modules/image/bifs/ImageGenerateCaptchaTest.java
+++ b/src/test/java/ortus/boxlang/modules/image/bifs/ImageGenerateCaptchaTest.java
@@ -31,12 +31,15 @@ import org.junit.jupiter.api.Test;
 
 import ortus.boxlang.compiler.parser.BoxSourceType;
 import ortus.boxlang.modules.image.BaseIntegrationTest;
-import ortus.boxlang.modules.image.BoxImage;
 import ortus.boxlang.runtime.scopes.Key;
 
 /**
  * Tests for ImageGenerateCaptcha BIF.
  * Argument order matches ColdFusion: height, width, text [, difficulty [, fonts [, fontSize]]]
+ *
+ * Note: Module classes run in an isolated classloader, so we avoid Java-side casts
+ * to BoxImage. Instead we verify via BoxLang code (getWidth/getHeight) or check
+ * the class simple name as a string.
  */
 public class ImageGenerateCaptchaTest extends BaseIntegrationTest {
 
@@ -51,20 +54,21 @@ public class ImageGenerateCaptchaTest extends BaseIntegrationTest {
 	@Test
 	public void testGenerateCaptchaReturnType() {
 		runtime.executeSource( """
-		    result = ImageGenerateCaptcha( 75, 200, "ABCD" );
-		""", context );
+		                           result = ImageGenerateCaptcha( 75, 200, "ABCD" );
+		                       """, context );
 
-		assertThat( variables.get( result ) ).isInstanceOf( BoxImage.class );
+		assertThat( variables.get( result ) ).isNotNull();
+		assertThat( variables.get( result ).getClass().getSimpleName() ).isEqualTo( "BoxImage" );
 	}
 
 	@DisplayName( "It generates a captcha with the specified dimensions" )
 	@Test
 	public void testGenerateCaptchaDimensions() {
 		runtime.executeSource( """
-		    result = ImageGenerateCaptcha( 100, 300, "HELLO" );
-		    w = result.getWidth();
-		    h = result.getHeight();
-		""", context );
+		                           result = ImageGenerateCaptcha( 100, 300, "HELLO" );
+		                           w = result.getWidth();
+		                           h = result.getHeight();
+		                       """, context );
 
 		assertThat( ( int ) variables.get( Key.of( "w" ) ) ).isEqualTo( 300 );
 		assertThat( ( int ) variables.get( Key.of( "h" ) ) ).isEqualTo( 100 );
@@ -75,9 +79,9 @@ public class ImageGenerateCaptchaTest extends BaseIntegrationTest {
 	public void testGenerateCaptchaLow() throws IOException {
 		String filePath = GENERATED_DIR + "captcha-low.png";
 		runtime.executeSource( """
-		    result = ImageGenerateCaptcha( 75, 200, "WXYZ", "low" );
-		    ImageWrite( result, "%s" );
-		""".formatted( filePath ), context );
+		                           result = ImageGenerateCaptcha( 75, 200, "WXYZ", "low" );
+		                           ImageWrite( result, "%s" );
+		                       """.formatted( filePath ), context );
 
 		Path p = Paths.get( filePath );
 		assertThat( Files.exists( p ) ).isTrue();
@@ -89,9 +93,9 @@ public class ImageGenerateCaptchaTest extends BaseIntegrationTest {
 	public void testGenerateCaptchaMedium() throws IOException {
 		String filePath = GENERATED_DIR + "captcha-medium.png";
 		runtime.executeSource( """
-		    result = ImageGenerateCaptcha( 75, 200, "WXYZ", "medium" );
-		    ImageWrite( result, "%s" );
-		""".formatted( filePath ), context );
+		                           result = ImageGenerateCaptcha( 75, 200, "WXYZ", "medium" );
+		                           ImageWrite( result, "%s" );
+		                       """.formatted( filePath ), context );
 
 		Path p = Paths.get( filePath );
 		assertThat( Files.exists( p ) ).isTrue();
@@ -103,9 +107,9 @@ public class ImageGenerateCaptchaTest extends BaseIntegrationTest {
 	public void testGenerateCaptchaHigh() throws IOException {
 		String filePath = GENERATED_DIR + "captcha-high.png";
 		runtime.executeSource( """
-		    result = ImageGenerateCaptcha( 75, 200, "WXYZ", "high" );
-		    ImageWrite( result, "%s" );
-		""".formatted( filePath ), context );
+		                           result = ImageGenerateCaptcha( 75, 200, "WXYZ", "high" );
+		                           ImageWrite( result, "%s" );
+		                       """.formatted( filePath ), context );
 
 		Path p = Paths.get( filePath );
 		assertThat( Files.exists( p ) ).isTrue();
@@ -117,9 +121,9 @@ public class ImageGenerateCaptchaTest extends BaseIntegrationTest {
 	public void testGenerateCaptchaWithFonts() throws IOException {
 		String filePath = GENERATED_DIR + "captcha-fonts.png";
 		runtime.executeSource( """
-		    result = ImageGenerateCaptcha( 75, 200, "CODE", "low", "SansSerif,Serif" );
-		    ImageWrite( result, "%s" );
-		""".formatted( filePath ), context );
+		                           result = ImageGenerateCaptcha( 75, 200, "CODE", "low", "SansSerif,Serif" );
+		                           ImageWrite( result, "%s" );
+		                       """.formatted( filePath ), context );
 
 		Path p = Paths.get( filePath );
 		assertThat( Files.exists( p ) ).isTrue();
@@ -131,26 +135,27 @@ public class ImageGenerateCaptchaTest extends BaseIntegrationTest {
 	public void testGenerateCaptchaWithFontSize() throws IOException {
 		String filePath = GENERATED_DIR + "captcha-fontsize.png";
 		runtime.executeSource( """
-		    result = ImageGenerateCaptcha( 100, 400, "BIG", "low", "", 36 );
-		    ImageWrite( result, "%s" );
-		""".formatted( filePath ), context );
+		                           result = ImageGenerateCaptcha( 100, 400, "BIG", "low", "", 36 );
+		                           ImageWrite( result, "%s" );
+		                           w = result.getWidth();
+		                           h = result.getHeight();
+		                       """.formatted( filePath ), context );
 
 		Path p = Paths.get( filePath );
 		assertThat( Files.exists( p ) ).isTrue();
 		assertThat( Files.size( p ) ).isGreaterThan( 0L );
-		BoxImage img = ( BoxImage ) variables.get( result );
-		assertThat( img.getWidth() ).isEqualTo( 400 );
-		assertThat( img.getHeight() ).isEqualTo( 100 );
+		assertThat( ( int ) variables.get( Key.of( "w" ) ) ).isEqualTo( 400 );
+		assertThat( ( int ) variables.get( Key.of( "h" ) ) ).isEqualTo( 100 );
 	}
 
 	@DisplayName( "It matches the ColdFusion 3-arg form: ImageGenerateCaptcha(height, width, text)" )
 	@Test
 	public void testColdFusionCompatThreeArgs() {
 		runtime.executeSource( """
-		    result = ImageGenerateCaptcha( 35, 400, "loner" );
-		    w = result.getWidth();
-		    h = result.getHeight();
-		""", context );
+		                           result = ImageGenerateCaptcha( 35, 400, "loner" );
+		                           w = result.getWidth();
+		                           h = result.getHeight();
+		                       """, context );
 
 		assertThat( ( int ) variables.get( Key.of( "w" ) ) ).isEqualTo( 400 );
 		assertThat( ( int ) variables.get( Key.of( "h" ) ) ).isEqualTo( 35 );
@@ -160,33 +165,46 @@ public class ImageGenerateCaptchaTest extends BaseIntegrationTest {
 	@Test
 	public void testColdFusionCompatFourArgs() {
 		runtime.executeSource( """
-		    result = ImageGenerateCaptcha( 35, 400, "loner", "high" );
-		""", context );
+		                           result = ImageGenerateCaptcha( 35, 400, "loner", "high" );
+		                           w = result.getWidth();
+		                           h = result.getHeight();
+		                       """, context );
 
-		assertThat( variables.get( result ) ).isInstanceOf( BoxImage.class );
+		assertThat( ( int ) variables.get( Key.of( "w" ) ) ).isEqualTo( 400 );
+		assertThat( ( int ) variables.get( Key.of( "h" ) ) ).isEqualTo( 35 );
 	}
 
 	@DisplayName( "It matches the ColdFusion 6-arg form: ImageGenerateCaptcha(height, width, text, difficulty, fonts, fontSize)" )
 	@Test
 	public void testColdFusionCompatSixArgs() {
 		runtime.executeSource( """
-		    result = ImageGenerateCaptcha( 35, 400, "loner", "high", "serif,sansserif", 24 );
-		""", context );
+		                           result = ImageGenerateCaptcha( 35, 400, "loner", "high", "serif,sansserif", 24 );
+		                           w = result.getWidth();
+		                           h = result.getHeight();
+		                       """, context );
 
-		assertThat( variables.get( result ) ).isInstanceOf( BoxImage.class );
+		assertThat( ( int ) variables.get( Key.of( "w" ) ) ).isEqualTo( 400 );
+		assertThat( ( int ) variables.get( Key.of( "h" ) ) ).isEqualTo( 35 );
 	}
 
 	@DisplayName( "It generates a captcha via bx:image component with name" )
 	@Test
 	public void testCaptchaComponentWithName() {
+		// Template call stores image in variables scope
 		runtime.executeSource( """
-		    <bx:image action="captcha" text="COMP" width="250" height="80" name="myCaptcha" />
-		""", context, BoxSourceType.BOXTEMPLATE );
+		                           <bx:image action="captcha" text="COMP" width="250" height="80" name="myCaptcha" />
+		                       """, context, BoxSourceType.BOXTEMPLATE );
 
-		BoxImage img = ( BoxImage ) variables.get( Key.of( "myCaptcha" ) );
-		assertThat( img ).isNotNull();
-		assertThat( img.getWidth() ).isEqualTo( 250 );
-		assertThat( img.getHeight() ).isEqualTo( 80 );
+		assertThat( variables.get( Key.of( "myCaptcha" ) ) ).isNotNull();
+
+		// Get dimensions via script mode on the same context
+		runtime.executeSource( """
+		                           w = myCaptcha.getWidth();
+		                           h = myCaptcha.getHeight();
+		                       """, context );
+
+		assertThat( ( int ) variables.get( Key.of( "w" ) ) ).isEqualTo( 250 );
+		assertThat( ( int ) variables.get( Key.of( "h" ) ) ).isEqualTo( 80 );
 	}
 
 	@DisplayName( "It generates a captcha via bx:image component with destination" )
@@ -196,15 +214,21 @@ public class ImageGenerateCaptchaTest extends BaseIntegrationTest {
 		Files.deleteIfExists( Paths.get( filePath ) );
 
 		runtime.executeSource( """
-		    <bx:image action="captcha" text="COMP" width="200" height="75"
-		              difficulty="medium" destination="%s" overwrite=true name="myCaptcha" />
-		""".formatted( filePath ), context, BoxSourceType.BOXTEMPLATE );
+		                           <bx:image action="captcha" text="COMP" width="200" height="75"
+		                                     difficulty="medium" destination="%s" overwrite=true name="myCaptcha" />
+		                       """.formatted( filePath ), context, BoxSourceType.BOXTEMPLATE );
 
 		assertThat( Files.exists( Paths.get( filePath ) ) ).isTrue();
 		assertThat( Files.size( Paths.get( filePath ) ) ).isGreaterThan( 0L );
+		assertThat( variables.get( Key.of( "myCaptcha" ) ) ).isNotNull();
 
-		BoxImage img = ( BoxImage ) variables.get( Key.of( "myCaptcha" ) );
-		assertThat( img ).isNotNull();
+		runtime.executeSource( """
+		                           w = myCaptcha.getWidth();
+		                           h = myCaptcha.getHeight();
+		                       """, context );
+
+		assertThat( ( int ) variables.get( Key.of( "w" ) ) ).isEqualTo( 200 );
+		assertThat( ( int ) variables.get( Key.of( "h" ) ) ).isEqualTo( 75 );
 	}
 
 }


### PR DESCRIPTION
Implements CAPTCHA image generation compatible with ColdFusion's
ImageCreateCaptcha(). Argument order matches CF: height, width, text
[, difficulty [, fonts [, fontSize]]].

Features:
- ImageGenerateCaptcha() BIF with configurable height, width, text,
  difficulty (low/medium/high), fonts, and fontSize
- <bx:image action="captcha"> component support; auto-streams to browser
  when neither name nor destination is specified
- Three difficulty levels: low (minimal rotation), medium (noise dots +
  crossing lines), high (heavy noise, wavy lines, random char colors)
- BoxImage.generateCaptcha() static factory method using Java2D

https://claude.ai/code/session_01K2EMwLTKMny586w5vWSmcB